### PR TITLE
removes setUseCache() as its useless and causes issues

### DIFF
--- a/traveler_core_kit/src/main/java/com/guestlogix/travelercorekit/task/NetworkTask.java
+++ b/traveler_core_kit/src/main/java/com/guestlogix/travelercorekit/task/NetworkTask.java
@@ -107,7 +107,6 @@ public class NetworkTask extends Task {
     private void setupConnection(HttpURLConnection conn) throws IOException {
         setHeaders(conn);
         setMethod(conn);
-        conn.setUseCaches(true);
     }
 
     private void setHeaders(HttpURLConnection urlConnection) {


### PR DESCRIPTION
httpurlconnection.setusecache() was generating exception. 
It does not do what the method name says so removing it.
https://stackoverflow.com/a/6847514/824345

Fixes #84 
