### PR TITLE
fix(stripe): replace material button with plain button

### DIFF
--- a/traveler_stripe_payment_provider/src/main/res/layout/activity_payment_collection.xml
+++ b/traveler_stripe_payment_provider/src/main/res/layout/activity_payment_collection.xml
@@ -14,7 +14,7 @@
             android:layout_margin="@dimen/margin_default"
             android:layout_centerHorizontal="true"/>
 
-    <com.google.android.material.button.MaterialButton
+    <Button
             android:id="@+id/done_button"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"


### PR DESCRIPTION
PaymentCollectionActivity wasn't inheriting from a material theme

```Caused by: java.lang.IllegalArgumentException: This component requires that you specify a valid TextAppearance attribute. Update your app theme to inherit from Theme.MaterialComponents (or a descendant).```