### PR TITLE
refactor(ui): move itinerary logic to fragment from activity

### DIFF
--- a/traveler_app/src/main/java/com/guestlogix/traveler/activities/ProfileActivity.java
+++ b/traveler_app/src/main/java/com/guestlogix/traveler/activities/ProfileActivity.java
@@ -68,8 +68,7 @@ public class ProfileActivity extends AppCompatActivity {
         findViewById(R.id.llItinerary).setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                Intent intent = new Intent(getApplicationContext(), ItineraryActivity.class);
-                intent.putExtra(ItineraryActivity.ARG_ITINERARY_QUERY, new ItineraryQuery(flights, null, null));
+                Intent intent = ItineraryActivity.buildIntent(ProfileActivity.this, new ItineraryQuery(flights, null, null));
                 startActivity(intent);
             }
         });

--- a/traveler_ui_kit/src/main/java/com/guestlogix/traveleruikit/itinerary/ItineraryActivity.java
+++ b/traveler_ui_kit/src/main/java/com/guestlogix/traveleruikit/itinerary/ItineraryActivity.java
@@ -1,172 +1,44 @@
 package com.guestlogix.traveleruikit.itinerary;
 
+import android.content.Context;
+import android.content.Intent;
 import android.os.Bundle;
 import android.util.Log;
-import android.view.View;
-import android.widget.Toast;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.fragment.app.Fragment;
-import androidx.fragment.app.FragmentTransaction;
 
-import com.guestlogix.travelercorekit.callbacks.ItineraryFetchCallback;
-import com.guestlogix.travelercorekit.models.ItineraryItem;
-import com.guestlogix.travelercorekit.models.ItineraryItemType;
 import com.guestlogix.travelercorekit.models.ItineraryQuery;
-import com.guestlogix.travelercorekit.models.ItineraryResult;
-import com.guestlogix.travelercorekit.models.Range;
-import com.guestlogix.travelercorekit.models.Traveler;
 import com.guestlogix.traveleruikit.R;
-import com.guestlogix.traveleruikit.fragments.LoadingFragment;
-import com.guestlogix.traveleruikit.fragments.RetryFragment;
-import com.guestlogix.traveleruikit.utils.FragmentTransactionQueue;
 
-import java.util.ArrayList;
-import java.util.Calendar;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.Date;
-import java.util.List;
+public class ItineraryActivity extends AppCompatActivity {
 
-public class ItineraryActivity extends AppCompatActivity implements ItineraryFetchCallback, RetryFragment.InteractionListener {
-    public static String ARG_ITINERARY_QUERY = "ARG_ITINERARY_QUERY";
+    private static final String ARG_ITINERARY_QUERY = "ARG_ITINERARY_QUERY";
 
-    private ItineraryQuery query;
-    private FragmentTransactionQueue transactionQueue;
-    ArrayList<ItineraryItemType> selectedItineraryItemTypes = new ArrayList<>();
-
-    ArrayList<ItineraryItem> lastRetrievedItineraryItems = null;
-    Date currentMinimumDate = null;
-    Date currentMaximumDate = null;
+    public static Intent buildIntent(@NonNull Context context, @NonNull ItineraryQuery query) {
+        Intent intent = new Intent(context, ItineraryActivity.class);
+        intent.putExtra(ARG_ITINERARY_QUERY, query);
+        return intent;
+    }
 
     @Override
-    protected void onCreate(Bundle savedInstanceState) {
+    protected void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-
         setContentView(R.layout.activity_itinerary);
 
-        transactionQueue = new FragmentTransactionQueue(getSupportFragmentManager());
-
-        query = (ItineraryQuery) getIntent().getSerializableExtra(ARG_ITINERARY_QUERY);
-
-        if (query == null) {
-            Log.e(this.getLocalClassName(), "a ItineraryQuery is required to run this activity");
+        if (getIntent().getSerializableExtra(ARG_ITINERARY_QUERY) == null) {
+            Log.e(this.getLocalClassName(), "Itinerary Query should not be null. Use `ItineraryActivity.buildIntent(context, query)` to create Intent");
             finish();
             return;
         }
 
-        selectedItineraryItemTypes.add(ItineraryItemType.BOOKING);
-        selectedItineraryItemTypes.add(ItineraryItemType.PARKING);
-
-        findViewById(R.id.btnFilters).setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                if (lastRetrievedItineraryItems == null)
-                    return;
-
-                //set start and end date
-                List<ItineraryItem> sortedItineraryItems = getSortedItineraryItems(lastRetrievedItineraryItems);
-                query.setStartDate(sortedItineraryItems.get(0).getStartDate());
-                query.setEndDate(sortedItineraryItems.get(sortedItineraryItems.size() - 1).getEndDate());
-
-
-                ItineraryFilters currentItineraryFilters = new ItineraryFilters(new Range<>(query.getStartDate(), query.getEndDate()), selectedItineraryItemTypes);
-
-
-                new ItineraryFilterDialog(ItineraryActivity.this, currentItineraryFilters, new ItineraryFilterDialog.ItineraryFiltersCallback() {
-                    @Override
-                    public void onFiltersChanged(ItineraryFilters itineraryFilters) {
-                        if (itineraryFilters.getDateRange().getLower().equals(currentItineraryFilters.getDateRange().getLower()) &&
-                                itineraryFilters.getDateRange().getUpper().equals(currentItineraryFilters.getDateRange().getUpper())) {
-
-                            if (!itineraryFilters.getSelectedItineraryItemTypes().equals(selectedItineraryItemTypes)) {
-                                filterTheResultCategoriesAndShow(itineraryFilters.getSelectedItineraryItemTypes());
-                                selectedItineraryItemTypes = itineraryFilters.getSelectedItineraryItemTypes();
-                            }
-
-                        } else {
-                            query = new ItineraryQuery(query.getFlights(), itineraryFilters.getDateRange().getLower(), itineraryFilters.getDateRange().getUpper());
-                            fetchItinerary();
-                        }
-                    }
-                }).show();
-            }
-        });
-
-        fetchItinerary();
-    }
-
-    private void fetchItinerary() {
-        Fragment loadingFragment = new LoadingFragment();
-        FragmentTransaction transaction = transactionQueue.newTransaction();
-        transaction.replace(R.id.itineraryContainer, loadingFragment);
-        transactionQueue.addTransaction(transaction);
-
-        Traveler.fetchItinerary(query, this);
-    }
-
-    @Override
-    public void onRetry() {
-        fetchItinerary();
-    }
-
-    @Override
-    public void onSuccess(ItineraryResult itineraryResult) {
-        if (itineraryResult.getItems().size() == 0) {
-            Toast.makeText(this, "Itinerary List is Empty", Toast.LENGTH_SHORT).show();
-            return;
-        }
-
-        lastRetrievedItineraryItems = itineraryResult.getItems();
-        filterTheResultCategoriesAndShow(selectedItineraryItemTypes);
-    }
-
-    @NonNull
-    private List<ItineraryItem> getSortedItineraryItems(List<ItineraryItem> itineraryItems) {
-        List<ItineraryItem> clonedItineraryList = new ArrayList<>(itineraryItems);
-        Collections.sort(clonedItineraryList, new Comparator<ItineraryItem>() {
-            @Override
-            public int compare(ItineraryItem o1, ItineraryItem o2) {
-                Calendar c1 = Calendar.getInstance();
-                c1.setTime(o1.getStartDate());
-                Calendar c2 = Calendar.getInstance();
-                c1.setTime(o2.getStartDate());
-                if (c1.get(Calendar.YEAR) < c2.get(Calendar.YEAR)) {
-                    return -1;
-                } else if (c1.get(Calendar.YEAR) == c2.get(Calendar.YEAR)) {
-                    if (c1.get(Calendar.DAY_OF_YEAR) < c2.get(Calendar.DAY_OF_YEAR)) {
-                        return -1;
-                    } else if (c1.get(Calendar.DAY_OF_YEAR) == c2.get(Calendar.DAY_OF_YEAR)) {
-                        return 0;
-                    } else {
-                        return 1;
-                    }
-                } else {
-                    return 1;
-                }
-            }
-        });
-        return clonedItineraryList;
-    }
-
-    @Override
-    public void onError(Error error) {
-        RetryFragment errorFragment = new RetryFragment();
-        FragmentTransaction transaction = transactionQueue.newTransaction();
-        transaction.replace(R.id.itineraryContainer, errorFragment);
-        transactionQueue.addTransaction(transaction);
-    }
-
-    private void filterTheResultCategoriesAndShow(ArrayList<ItineraryItemType> lstCurrentlySelectedItineraryItemTypes) {
-        ArrayList<ItineraryItem> filteredItineraryItems = new ArrayList<>();
-        for (ItineraryItem itineraryItem : lastRetrievedItineraryItems) {
-            if (lstCurrentlySelectedItineraryItemTypes.contains(itineraryItem.getItineraryItemType()))
-                filteredItineraryItems.add(itineraryItem);
-        }
-        Fragment ordersFragment = ItineraryFragment.newInstance(filteredItineraryItems);
-        FragmentTransaction transaction = transactionQueue.newTransaction();
-        transaction.replace(R.id.itineraryContainer, ordersFragment);
-        transactionQueue.addTransaction(transaction);
+        ItineraryQuery itineraryQuery = (ItineraryQuery) getIntent().getSerializableExtra(ARG_ITINERARY_QUERY);
+        Fragment fragment = ItineraryPreviewFragment.newInstance(itineraryQuery);
+        getSupportFragmentManager()
+                .beginTransaction()
+                .replace(R.id.itinerary_fragment_container, fragment)
+                .commit();
     }
 }

--- a/traveler_ui_kit/src/main/java/com/guestlogix/traveleruikit/itinerary/ItineraryEmptyFragment.java
+++ b/traveler_ui_kit/src/main/java/com/guestlogix/traveleruikit/itinerary/ItineraryEmptyFragment.java
@@ -1,0 +1,21 @@
+package com.guestlogix.traveleruikit.itinerary;
+
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.fragment.app.Fragment;
+
+import com.guestlogix.traveleruikit.R;
+
+public class ItineraryEmptyFragment extends Fragment {
+
+    @Nullable
+    @Override
+    public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
+        return inflater.inflate(R.layout.fragment_itinerary_empty, container, false);
+    }
+}

--- a/traveler_ui_kit/src/main/java/com/guestlogix/traveleruikit/itinerary/ItineraryPreviewFragment.java
+++ b/traveler_ui_kit/src/main/java/com/guestlogix/traveleruikit/itinerary/ItineraryPreviewFragment.java
@@ -1,0 +1,193 @@
+package com.guestlogix.traveleruikit.itinerary;
+
+import android.os.Bundle;
+import android.util.Log;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.fragment.app.Fragment;
+import androidx.fragment.app.FragmentTransaction;
+
+import com.guestlogix.travelercorekit.callbacks.ItineraryFetchCallback;
+import com.guestlogix.travelercorekit.models.ItineraryItem;
+import com.guestlogix.travelercorekit.models.ItineraryItemType;
+import com.guestlogix.travelercorekit.models.ItineraryQuery;
+import com.guestlogix.travelercorekit.models.ItineraryResult;
+import com.guestlogix.travelercorekit.models.Range;
+import com.guestlogix.travelercorekit.models.Traveler;
+import com.guestlogix.traveleruikit.R;
+import com.guestlogix.traveleruikit.fragments.LoadingFragment;
+import com.guestlogix.traveleruikit.fragments.RetryFragment;
+import com.guestlogix.traveleruikit.utils.FragmentTransactionQueue;
+
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.Date;
+import java.util.List;
+
+public class ItineraryPreviewFragment extends Fragment implements ItineraryFetchCallback, RetryFragment.InteractionListener {
+    public static String ARG_ITINERARY_QUERY = "ARG_ITINERARY_QUERY";
+
+    private ItineraryQuery query;
+    private FragmentTransactionQueue transactionQueue;
+    ArrayList<ItineraryItemType> selectedItineraryItemTypes = new ArrayList<>();
+    ArrayList<ItineraryItem> lastRetrievedItineraryItems = null;
+    Date currentMinimumDate = null;
+    Date currentMaximumDate = null;
+
+    public static ItineraryPreviewFragment newInstance(ItineraryQuery itineraryQuery) {
+        Bundle args = new Bundle();
+        args.putSerializable(ARG_ITINERARY_QUERY, itineraryQuery);
+        ItineraryPreviewFragment fragment = new ItineraryPreviewFragment();
+        fragment.setArguments(args);
+        return fragment;
+    }
+
+    @Nullable
+    @Override
+    public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
+        return inflater.inflate(R.layout.fragment_itinerary_preview, container, false);
+    }
+
+    @Override
+    public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
+        super.onViewCreated(view, savedInstanceState);
+        transactionQueue = new FragmentTransactionQueue(getChildFragmentManager());
+
+        if (getArguments() != null && getArguments().getSerializable(ARG_ITINERARY_QUERY) != null) {
+            query = (ItineraryQuery) getArguments().getSerializable(ARG_ITINERARY_QUERY);
+        }
+
+        if (query == null) {
+            Log.e(this.getClass().getSimpleName(), "a ItineraryQuery is required to run this activity");
+            return;
+        }
+
+        selectedItineraryItemTypes.add(ItineraryItemType.BOOKING);
+        selectedItineraryItemTypes.add(ItineraryItemType.PARKING);
+        selectedItineraryItemTypes.add(ItineraryItemType.FLIGHT);
+
+        view.findViewById(R.id.btnFilters).setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                if (lastRetrievedItineraryItems == null)
+                    return;
+
+                //set start and end date
+                List<ItineraryItem> sortedItineraryItems = getSortedItineraryItems(lastRetrievedItineraryItems);
+                query.setStartDate(sortedItineraryItems.get(0).getStartDate());
+                query.setEndDate(sortedItineraryItems.get(sortedItineraryItems.size() - 1).getEndDate());
+
+                ItineraryFilters currentItineraryFilters = new ItineraryFilters(new Range<>(query.getStartDate(), query.getEndDate()), selectedItineraryItemTypes);
+
+                new ItineraryFilterDialog(getContext(), currentItineraryFilters, new ItineraryFilterDialog.ItineraryFiltersCallback() {
+                    @Override
+                    public void onFiltersChanged(ItineraryFilters itineraryFilters) {
+                        if (itineraryFilters.getDateRange().getLower().equals(currentItineraryFilters.getDateRange().getLower()) &&
+                                itineraryFilters.getDateRange().getUpper().equals(currentItineraryFilters.getDateRange().getUpper())) {
+
+                            if (!itineraryFilters.getSelectedItineraryItemTypes().equals(selectedItineraryItemTypes)) {
+                                filterTheResultCategoriesAndShow(itineraryFilters.getSelectedItineraryItemTypes());
+                                selectedItineraryItemTypes = itineraryFilters.getSelectedItineraryItemTypes();
+                            }
+
+                        } else {
+                            query = new ItineraryQuery(query.getFlights(), itineraryFilters.getDateRange().getLower(), itineraryFilters.getDateRange().getUpper());
+                            fetchItinerary();
+                        }
+                    }
+                }).show();
+            }
+        });
+
+        fetchItinerary();
+    }
+
+    private void fetchItinerary() {
+        Fragment loadingFragment = new LoadingFragment();
+        FragmentTransaction transaction = transactionQueue.newTransaction();
+        transaction.replace(R.id.itineraryContainer, loadingFragment);
+        transactionQueue.addTransaction(transaction);
+
+        Traveler.fetchItinerary(query, this);
+    }
+
+    @Override
+    public void onRetry() {
+        fetchItinerary();
+    }
+
+    @Override
+    public void onSuccess(ItineraryResult itineraryResult) {
+        if (itineraryResult.getItems().size() == 0) {
+            showEmptyItineraryList();
+            return;
+        }
+
+        lastRetrievedItineraryItems = itineraryResult.getItems();
+        filterTheResultCategoriesAndShow(selectedItineraryItemTypes);
+    }
+
+    private void showEmptyItineraryList() {
+        FragmentTransaction transaction = transactionQueue.newTransaction();
+        transaction.replace(R.id.itineraryContainer, new ItineraryEmptyFragment());
+        transactionQueue.addTransaction(transaction);
+    }
+
+    @NonNull
+    private List<ItineraryItem> getSortedItineraryItems(List<ItineraryItem> itineraryItems) {
+        List<ItineraryItem> clonedItineraryList = new ArrayList<>(itineraryItems);
+        Collections.sort(clonedItineraryList, new Comparator<ItineraryItem>() {
+            @Override
+            public int compare(ItineraryItem o1, ItineraryItem o2) {
+                Calendar c1 = Calendar.getInstance();
+                c1.setTime(o1.getStartDate());
+                Calendar c2 = Calendar.getInstance();
+                c1.setTime(o2.getStartDate());
+                if (c1.get(Calendar.YEAR) < c2.get(Calendar.YEAR)) {
+                    return -1;
+                } else if (c1.get(Calendar.YEAR) == c2.get(Calendar.YEAR)) {
+                    if (c1.get(Calendar.DAY_OF_YEAR) < c2.get(Calendar.DAY_OF_YEAR)) {
+                        return -1;
+                    } else if (c1.get(Calendar.DAY_OF_YEAR) == c2.get(Calendar.DAY_OF_YEAR)) {
+                        return 0;
+                    } else {
+                        return 1;
+                    }
+                } else {
+                    return 1;
+                }
+            }
+        });
+        return clonedItineraryList;
+    }
+
+    @Override
+    public void onError(Error error) {
+        RetryFragment errorFragment = new RetryFragment();
+        FragmentTransaction transaction = transactionQueue.newTransaction();
+        transaction.replace(R.id.itineraryContainer, errorFragment);
+        transactionQueue.addTransaction(transaction);
+    }
+
+    private void filterTheResultCategoriesAndShow(ArrayList<ItineraryItemType> lstCurrentlySelectedItineraryItemTypes) {
+        ArrayList<ItineraryItem> filteredItineraryItems = new ArrayList<>();
+        for (ItineraryItem itineraryItem : lastRetrievedItineraryItems) {
+            if (lstCurrentlySelectedItineraryItemTypes.contains(itineraryItem.getItineraryItemType()))
+                filteredItineraryItems.add(itineraryItem);
+        }
+        if (filteredItineraryItems.isEmpty()) {
+            showEmptyItineraryList();
+            return;
+        }
+        Fragment ordersFragment = ItineraryFragment.newInstance(filteredItineraryItems);
+        FragmentTransaction transaction = transactionQueue.newTransaction();
+        transaction.replace(R.id.itineraryContainer, ordersFragment);
+        transactionQueue.addTransaction(transaction);
+    }
+}

--- a/traveler_ui_kit/src/main/res/layout/activity_itinerary.xml
+++ b/traveler_ui_kit/src/main/res/layout/activity_itinerary.xml
@@ -1,23 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-        xmlns:app="http://schemas.android.com/apk/res-auto"
-        xmlns:tools="http://schemas.android.com/tools"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:orientation="vertical"
-        tools:context="com.guestlogix.traveleruikit.activities.OrdersActivity">
-
-    <Button
-            android:id="@+id/btnFilters"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="right"
-            android:layout_margin="10dp"
-            android:text="Filters" />
-
-    <FrameLayout
-            android:id="@+id/itineraryContainer"
-            android:layout_width="match_parent"
-            android:layout_height="0dp"
-            android:layout_weight="1" />
-</LinearLayout>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/itinerary_fragment_container"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent" />

--- a/traveler_ui_kit/src/main/res/layout/fragment_itinerary_empty.xml
+++ b/traveler_ui_kit/src/main/res/layout/fragment_itinerary_empty.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:gravity="center">
+
+    <androidx.appcompat.widget.AppCompatTextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center"
+        android:text="@string/empty_itinerary"
+        android:textColor="@color/black"
+        android:textStyle="bold" />
+
+</LinearLayout>

--- a/traveler_ui_kit/src/main/res/layout/fragment_itinerary_preview.xml
+++ b/traveler_ui_kit/src/main/res/layout/fragment_itinerary_preview.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    tools:context="com.guestlogix.traveleruikit.activities.OrdersActivity">
+
+    <Button
+        android:id="@+id/btnFilters"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="right"
+        android:layout_margin="10dp"
+        android:text="Filters" />
+
+    <FrameLayout
+        android:id="@+id/itineraryContainer"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1" />
+</LinearLayout>

--- a/traveler_ui_kit/src/main/res/values/strings.xml
+++ b/traveler_ui_kit/src/main/res/values/strings.xml
@@ -132,5 +132,6 @@
     <string name="label_terms_and_conditions">Terms and conditions</string>
     <string name="itinerary_terms_and_conditions">Terms and conditions</string>
 
+    <string name="empty_itinerary">Your itinerary is empty</string>
 
 </resources>


### PR DESCRIPTION
Description
PR moves ItineraryActivity business logic to fragment. It leaves activity as a wrapper around fragment with logic. This was necessary so that SDK users could implement Itinerary feature anywhere in the app (e.g. as a tab fragment on dashboard as we have the case in WL app)